### PR TITLE
Feature: Disable Memory Card Emulation per GC Game

### DIFF
--- a/source/gui/guigamesview.cpp
+++ b/source/gui/guigamesview.cpp
@@ -180,6 +180,8 @@ void GuiGamesView::openGameConfig(u32 idx) {
                 gameConfig.setValue("Video mode", NIN_VID_AUTO);
             if (!gameConfig.getValue("Language", &tempVal))
                 gameConfig.setValue("Language", NIN_LAN_AUTO);
+            if (!gameConfig.getValue("Memory Card Emulation", &tempVal))
+                gameConfig.setValue("Memory Card Emulation", 1);
 
             //GC+2.0 mapping
             if (!gameConfig.getValue("GCPMap_A", &tempVal))
@@ -564,7 +566,6 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             cfg.Version = NIN_CFG_VERSION;
             cfg.Config = NIN_CFG_AUTO_BOOT;
             cfg.Config |= NIN_CFG_USB;
-            cfg.Config |= NIN_CFG_MEMCARDEMU;
             cfg.Config |= NIN_CFG_HID;
 
             tempVal = 0;
@@ -604,6 +605,11 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             } else {
                 cfg.Language = NIN_LAN_AUTO;
             }
+
+            tempVal = 1;
+            thisView->gameConfig.getValue("Memory Card Emulation", &tempVal);
+            if (tempVal)
+                cfg.Config |= NIN_CFG_MEMCARDEMU;
 
             //GC+2.0 map
             thisView->gameConfig.getValue("GCPMap_A", &thisView->gcpMap[GCP_MAP_BUTTON_A_ID]);

--- a/theme/scripts/gamesview.lua
+++ b/theme/scripts/gamesview.lua
@@ -50,9 +50,9 @@ function init()
 
     if GamesView.getGamesType() == GamesView.gameType.GC_GAME then
         if Gcp.isV2() then
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Configure GC+2.0 map"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Memory Card Emulation", "Configure GC+2.0 map"})
         else
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Memory Card Emulation", "Language"})
         end
     elseif GamesView.getGamesType() == GamesView.gameType.WII_GAME then
         gameConfigSelectedEnum = enum({"Enable WiFi", "Enable Bluetooth", "Enable USB saves", "Enable GC2Wiimote", "Configure GC2Wiimote"})
@@ -352,6 +352,15 @@ function drawGameConfig()
             val = "Italian"
         elseif val == GamesView.nintendont.LANG_DUTCH then
             val = "Dutch"
+        end
+        menuSystem.printLineValue(val, false)
+
+        menuSystem.printLine("Memory Card Emulation", gameConfigSelected.id)
+        local val = GamesView.getGameConfigValue("Memory Card Emulation")
+        if val == GamesView.config.YES then
+            val = "Yes"
+        else
+            val = "No"
         end
         menuSystem.printLineValue(val, false)
 


### PR DESCRIPTION
This adds the option to opt-out Nintendonts Memcard Emulation in the games settings menu. Per defaults it's activated.