### PR TITLE
Feature: Show MX-Chip detection in status menu

### DIFF
--- a/theme/scripts/systemStatus.lua
+++ b/theme/scripts/systemStatus.lua
@@ -11,6 +11,9 @@ function drawSystemStatus(onFocus)
     if UAMP.isConnected() then
         menuSystem.printLine("UAMP HUD detected")
     end
+    if Time.available() then
+        menuSystem.printLine("MX-Chip detected")
+    end
 
     if PMS2.isConnected() then
         local chargeStatus = PMS2.getChargeStatus()


### PR DESCRIPTION
Tiny feature that shows "MX-Chip detected" in `Settings` -> `Status`.

