### PR TITLE
Feature: Enable cheats per gamecube game

### DIFF
--- a/source/gui/guigamesview.cpp
+++ b/source/gui/guigamesview.cpp
@@ -180,6 +180,8 @@ void GuiGamesView::openGameConfig(u32 idx) {
                 gameConfig.setValue("Video mode", NIN_VID_AUTO);
             if (!gameConfig.getValue("Language", &tempVal))
                 gameConfig.setValue("Language", NIN_LAN_AUTO);
+            if (!gameConfig.getValue("Enable Cheats", &tempVal))
+                gameConfig.setValue("Enable Cheats", 0);
             if (!gameConfig.getValue("Memory Card Emulation", &tempVal))
                 gameConfig.setValue("Memory Card Emulation", 1);
 
@@ -605,6 +607,11 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             } else {
                 cfg.Language = NIN_LAN_AUTO;
             }
+
+            tempVal = 0;
+            thisView->gameConfig.getValue("Enable Cheats", &tempVal);
+            if (tempVal)
+                cfg.Config |= NIN_CFG_CHEATS;
 
             tempVal = 1;
             thisView->gameConfig.getValue("Memory Card Emulation", &tempVal);

--- a/theme/scripts/gamesview.lua
+++ b/theme/scripts/gamesview.lua
@@ -50,9 +50,9 @@ function init()
 
     if GamesView.getGamesType() == GamesView.gameType.GC_GAME then
         if Gcp.isV2() then
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Memory Card Emulation", "Configure GC+2.0 map"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Enable Cheats", "Memory Card Emulation", "Configure GC+2.0 map"})
         else
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Memory Card Emulation", "Language"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Enable Cheats", "Memory Card Emulation", "Language"})
         end
     elseif GamesView.getGamesType() == GamesView.gameType.WII_GAME then
         gameConfigSelectedEnum = enum({"Enable WiFi", "Enable Bluetooth", "Enable USB saves", "Enable GC2Wiimote", "Configure GC2Wiimote"})
@@ -352,6 +352,15 @@ function drawGameConfig()
             val = "Italian"
         elseif val == GamesView.nintendont.LANG_DUTCH then
             val = "Dutch"
+        end
+        menuSystem.printLineValue(val, false)
+
+        menuSystem.printLine("Enable Cheats", gameConfigSelected.id)
+        local val = GamesView.getGameConfigValue("Enable Cheats")
+        if val == GamesView.config.YES then
+            val = "Yes"
+        else
+            val = "No"
         end
         menuSystem.printLineValue(val, false)
 


### PR DESCRIPTION
Here is another addition to the game settings for GC games that allows to enable cheats in Nintendont.

It's  been tested successfully but might get some more testing from the community.

This is also the last Item we can add to the Settings menu without reformating the menu itself :D 