### PR TITLE
Expose Nintendont "Max Pads" config and tweak config reading

### DIFF
--- a/include/nintendont.h
+++ b/include/nintendont.h
@@ -4,8 +4,6 @@
 
 #define NIN_CFG_VERSION     0x00000008
 
-#define NIN_CFG_MAXPAD 4
-
 typedef struct NIN_CFG
 {
     unsigned int        Magicbytes;     // 0x01070CF6

--- a/source/gui/guigamesview.cpp
+++ b/source/gui/guigamesview.cpp
@@ -594,21 +594,13 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             if (tempVal)
                 cfg.Config |= NIN_CFG_NATIVE_SI;
 
-            tempVal = 0;
+            tempVal = NIN_VID_AUTO;
             thisView->gameConfig.getValue("Video mode", &tempVal);
-            if (tempVal) {
-                cfg.VideoMode = tempVal;
-            } else {
-                cfg.VideoMode = NIN_VID_AUTO;
-            }
+            cfg.VideoMode = tempVal;
 
-            tempVal = 0;
+            tempVal = NIN_LAN_AUTO;
             thisView->gameConfig.getValue("Language", &tempVal);
-            if (tempVal) {
-                cfg.Language = tempVal;
-            } else {
-                cfg.Language = NIN_LAN_AUTO;
-            }
+            cfg.Language = tempVal;
 
             tempVal = 0;
             thisView->gameConfig.getValue("Enable Cheats", &tempVal);

--- a/source/gui/guigamesview.cpp
+++ b/source/gui/guigamesview.cpp
@@ -184,6 +184,8 @@ void GuiGamesView::openGameConfig(u32 idx) {
                 gameConfig.setValue("Enable Cheats", 0);
             if (!gameConfig.getValue("Memory Card Emulation", &tempVal))
                 gameConfig.setValue("Memory Card Emulation", 1);
+            if (!gameConfig.getValue("Max Pads", &tempVal))
+                gameConfig.setValue("Max Pads", 4);
 
             //GC+2.0 mapping
             if (!gameConfig.getValue("GCPMap_A", &tempVal))
@@ -618,6 +620,10 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             if (tempVal)
                 cfg.Config |= NIN_CFG_MEMCARDEMU;
 
+            tempVal = 4;
+            thisView->gameConfig.getValue("Max Pads", &tempVal);
+            cfg.MaxPads = tempVal;
+
             //GC+2.0 map
             thisView->gameConfig.getValue("GCPMap_A", &thisView->gcpMap[GCP_MAP_BUTTON_A_ID]);
             thisView->gameConfig.getValue("GCPMap_B", &thisView->gcpMap[GCP_MAP_BUTTON_B_ID]);
@@ -640,7 +646,6 @@ int GuiGamesView::lua_bootGame(lua_State* L) {
             }
 
             strcpy(cfg.GamePath, gc.path.c_str());
-            cfg.MaxPads = NIN_CFG_MAXPAD;
             cfg.GameID = gc.gameID;
             bootGCGame(cfg);
         } else if (thisView->titlesType == WII_VC) {

--- a/static/theme/scripts/gamesview.lua
+++ b/static/theme/scripts/gamesview.lua
@@ -53,9 +53,9 @@ function init()
 
     if GamesView.getGamesType() == GamesView.gameType.GC_GAME then
         if Gcp.isV2() then
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Enable Cheats", "Memory Card Emulation", "Configure GC+2.0 map"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Enable Cheats", "Memory Card Emulation", "Max Pads", "Configure GC+2.0 map"})
         else
-            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Enable Cheats", "Memory Card Emulation"})
+            gameConfigSelectedEnum = enum({"Force progressive", "Force widescreen", "Force RVL-DD stretching", "Native SI", "Video mode", "Language", "Enable Cheats", "Memory Card Emulation", "Max Pads"})
         end
     elseif GamesView.getGamesType() == GamesView.gameType.WII_GAME then
         gameConfigSelectedEnum = enum({"Enable WiFi", "Enable Bluetooth", "Enable USB saves", "Enable GC2Wiimote", "Configure GC2Wiimote"})
@@ -376,6 +376,10 @@ function drawGameConfig()
         end
         menuSystem:printLineValue(val, false)
 
+        menuSystem:printLine("Max Pads", gameConfigSelected.id)
+        local val = GamesView.getGameConfigValue("Max Pads")
+        menuSystem:printLineValue(tostring(val), false)
+
         if Gcp.isV2() then
             menuSystem:printLine("Configure GC+2.0 map", gameConfigSelected.id)
         end
@@ -567,6 +571,12 @@ function handleGameConfig()
                 elseif confVal == GamesView.nintendont.LANG_DUTCH then
                     confVal = GamesView.nintendont.LANG_ITALIAN
                 end
+            end
+        elseif gameConfigSelected == gameConfigSelectedEnum["Max Pads"] then
+            if down.BUTTON_RIGHT then
+                confVal = confVal < 4 and confVal + 1 or 0
+            elseif down.BUTTON_LEFT then
+                confVal = confVal > 0 and confVal - 1 or 4
             end
         else --Yes/No configs
             if down.BUTTON_RIGHT or down.BUTTON_LEFT or down.BUTTON_A then


### PR DESCRIPTION
The main change here is changing the mentioned `Max Pads` setting from being hardcoded to adjustable.
Given the setting is already passed as an `int`, no fundamental change had to occur, and I was able to confirm it works on hardware when applying the changes to the `1.5` tag of RVLoader.
Behavior with the possible values appears consistent with what occurs when setting those values in Nintendont directly.

The secondary change is removing the `if (tempVal)` checks from Language and VideoMode settings.
As far as my reading goes, this is required for manually setting Language to English to function, as both English and the default `tempVal` that gets changed to Auto are `0`.
VideoMode doesn't appear to have this issue, but was changed for consistency since the option is similar.
This shouldn't introduce any failure states that weren't already possible originally (e.g. setting an invalid value in a game `txt` file manually), unless I'm missing something.

Hopefully these changes are sensible; I'll do my best to explain or adjust anything if necessary.