### PR TITLE
Fix usage of BUTTON_RIGHT in BUTTON_LEFT code

### DIFF
--- a/driveRoot/rvloader/themes/main/scripts/powerSettings.lua
+++ b/driveRoot/rvloader/themes/main/scripts/powerSettings.lua
@@ -499,7 +499,7 @@ function powerSettings:handleInputs(onFocus)
             end
         end
 
-        if down.BUTTON_RIGHT then
+        if down.BUTTON_LEFT then
             self.autoIncreaseTime = Time.getms() + self.AUTO_INCREASE_DELAY
         else
             self.autoIncreaseTime = Time.getms() + self.AUTO_INCREASE_TIME


### PR DESCRIPTION
In code that allows for the increase of settings, a logic statement checks if BUTTON_RIGHT is being held, to allow for accelerating value increases. There is also code that does the opposite, decreasing setting values. However, the code to handle acceleration of that still checks for BUTTON_RIGHT, instead of BUTTON_LEFT.

https://discord.com/channels/183358534266781706/600667441831346196/1356778462395895888