### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/lua-5.4.2/src/lparser.c
+++ b/lua-5.4.2/src/lparser.c
@@ -457,6 +457,7 @@ static void singlevar (LexState *ls, expdesc *var) {
     expdesc key;
     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
     lua_assert(var->k != VVOID);  /* this one must exist */
+    luaK_exp2anyregup(fs, var);  /* but could be a constant */
     codestring(&key, varname);  /* key is variable name */
     luaK_indexed(fs, var, &key);  /* env[varname] */
   }


### PR DESCRIPTION
This PR fixes a potential security vulnerability in singlevar() that was cloned from https://github.com/lua/lua but did not receive the security patch.

### Details:
Lua can generate wrong code when _ENV is <const>
Affected Function: singlevar() in lua-5.4.2/src/lparser.c
Original Fix: https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa
- https://nvd.nist.gov/vuln/detail/cve-2022-28805

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
